### PR TITLE
convert plugin.json to new format

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,14 +1,16 @@
 {
-  "plugin": {
+    "pluginmetadataversion" : 2,
     "name": "Function ABI",
-    "version": "0.1",
-    "author": "whitequark",
     "type": ["ui"],
-    "api": "python2",
+    "api": ["python2", "python3"],
     "description": "A plugin that adds a GUI for changing function ABI.",
     "longdescription": "This plugin provides a GUI for adjusting the ABI in a fine-grained way. Calling convention and clobbered registers can be adjusted.",
+    "version": "0.1",
+    "author": "whitequark",
+    "minimumbinaryninjaversion": 555,
+    "platforms": ["Darwin", "Linux", "Windows"],
     "license": {
-      "name": "BSD-0-clause"
+        "name": "BSD-0-clause",
+        "text": "Copyright (C) 2018 by whitequark\n\nPermission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE."
     }
-  }
 }


### PR DESCRIPTION
Created a pull request for the new plugin manager format. Please note that a release is still required which I can't do, but it should look something like:

```
git tag -a 0.1
git push origin 0.1
brew install hub || sudo snap install --classic hub || echo install method of your choice
hub release create 0.1
```
