### PR TITLE
Fix cconv_names typing (for api ver 1.2.1957)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -25,7 +25,7 @@ def abi_dialog(view, addr):
 
     arch = view.platform.arch
     cconvs = view.platform.calling_conventions
-    cconv_names = map(lambda x: x.name, cconvs)
+    cconv_names = list(map(lambda x: x.name, cconvs))
     cconv = func.calling_convention
     clobbers = set(func.clobbered_regs)
     cconv_clobbers = set([cconv.int_return_reg] + cconv.int_arg_regs + cconv.caller_saved_regs)


### PR DESCRIPTION
I'm not sure if this worked with a previous API version, but the current version of get_form_input() doesn't allow any of the fields param to be maps. I don't see any negative side effects to this simple fix.